### PR TITLE
fix: use `aliasesExclude` to avoid internal relative paths

### DIFF
--- a/packages/responsive/vite.config.ts
+++ b/packages/responsive/vite.config.ts
@@ -16,7 +16,11 @@ export default defineConfig(() => ({
   plugins: [
     nxViteTsPaths(),
     nxCopyAssetsPlugin(['*.md', 'web-types.json']),
-    dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'), pathsToAliases: true }),
+    dts({
+      entryRoot: 'src',
+      tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+      aliasesExclude: [/@trunkjs\/.*/],
+    }),
   ],
   // Uncomment this if you are using workers.
   // worker: {


### PR DESCRIPTION
@dermatthes Die relativen Pfade in den `.d.ts`-Dateien sind wohl Standard im vite-plugin-dts in Version 4+.

Mit der Option `aliasesExclude` auf die internen Pakete wird dann anhand der Paket-Namen importiert; nicht mit aufgelöstem relativem Pfad.

<img width="658" height="119" alt="Bildschirmfoto 2025-12-15 um 08 24 57" src="https://github.com/user-attachments/assets/e8ca29e8-7a03-48dc-add1-8f53393e5d7e" />
