### PR TITLE
document content pane layout index and nesting

### DIFF
--- a/packages/content-pane/.ai-usage-info.md
+++ b/packages/content-pane/.ai-usage-info.md
@@ -2,187 +2,141 @@
 
 ## Purpose
 
-Turns flat content into nested sections and applies `layout`-based element transforms.
-
-Use it when content comes in shapes like:
-- markdown-rendered HTML
-- CMS output
-- flat `h2/h3/hr/p/...` sequences
+Turns flat HTML content into a nested section tree and applies `layout`-based element transforms.
 
 Typical flow:
-1. build nested `<section>` structure from headings / `hr`
-2. replace wrapper sections via `layout="..."`
-
-## Import
+1. build nested `<section>` structure from headings and `hr[layout]`
+2. replace generated sections via `layout="..."`
 
 ```ts
 import '@trunkjs/content-pane';
 ```
 
-Or use helpers directly:
+## Core concept: layout index `i`
+
+The layout index `i` is the nesting coordinate: **smaller = outer, larger = deeper**.
+
+Default heading indices:
+
+```text
+h1 -> i=2
+h2 -> i=2
+h3 -> i=3
+h4 -> i=4
+h5 -> i=5
+h6 -> i=6
+```
+
+`h1` intentionally behaves like `h2`, so normal content starts at `i=2`.
+
+Higher indices become children of the preceding lower index. A new element at the same or a lower index closes the previous nesting path as required.
+
+## Preferred layout pattern: attach layouts to headings
+
+Prefer putting `layout` directly on the heading that owns the section. This keeps layout structure aligned with semantic document structure.
+
+```html
+<h2 layout="page-section">Products</h2>
+<h3>Product A</h3>
+<h3>Product B</h3>
+```
+
+Conceptually:
+
+```text
+page-section / h2  i=2
+├─ h3              i=3
+└─ h3              i=3
+```
+
+## Extra wrapper between heading levels: `hr[layout]`
+
+Use `hr[layout]` when several following elements of the next level need an additional common layout wrapper.
+
+An HR without an explicit index uses:
+
+```text
+i = last fixed index + 0.5
+```
+
+```html
+<h2>Products</h2>
+<hr layout="card-grid">
+<h3>Product A</h3>
+<h3>Product B</h3>
+```
+
+Conceptually:
+
+```text
+h2             i=2
+└─ card-grid   i=2.5
+   ├─ h3       i=3
+   └─ h3       i=3
+```
+
+An `<hr>` without `layout` is ignored by the section builder.
+
+## `layout` index syntax
+
+```html
+<h2 layout="3;card-box">...</h2>
+<h3 layout="+3;">...</h3>
+<h3 layout="-3;">...</h3>
+```
+
+- `i;layout` — create a new section at explicit index `i`.
+- `+i;...` — append the element to the existing section at that index instead of creating a new section.
+- `-i;...` — skip section creation for this element and append it to the current container.
+- no explicit `i` — derive `i` from the heading; for `hr[layout]`, use the last fixed index + `0.5`.
+
+Explicit outer levels such as `i=1` are possible for page-wide wrappers/backgrounds, but use them sparingly: all following deeper content will be nested inside until the tree returns to that level or above.
+
+## Layout selector
+
+The part after the optional index prefix defines the replacement element and attributes:
+
+```html
+<h2 layout="card-box#intro.highlight[slot=main]">Intro</h2>
+```
+
+Result idea:
+
+```html
+<card-box id="intro" class="highlight" slot="main">
+  <h2>Intro</h2>
+</card-box>
+```
+
+## Section attributes
+
+Use `section-*` on source headings to configure the generated section:
+
+```html
+<h2 section-id="intro" section-class="hero" section-style="--cols: 6">Intro</h2>
+```
+
+Source classes prefixed with `section-` are also copied to the generated section without the prefix.
+
+## Direct helpers
 
 ```ts
 import { applyLayout, SectionTreeBuilder, SubLayoutApplyMixin } from '@trunkjs/content-pane';
 ```
 
-## Main usage: `<tj-content-pane>`
-
-Input:
-
-```html
-<tj-content-pane>
-  <h2>Intro</h2>
-  <p>Text</p>
-
-  <h3>Details</h3>
-  <p>More text</p>
-</tj-content-pane>
-```
-
-Result idea:
-
-```html
-<tj-content-pane>
-  <section>
-    <h2>Intro</h2>
-    <p>Text</p>
-    <section>
-      <h3>Details</h3>
-      <p>More text</p>
-    </section>
-  </section>
-</tj-content-pane>
-```
-
-## `layout` examples
-
-### Replace generated wrapper element
-
-```html
-<h2 layout="card-box#intro.highlight">Intro</h2>
-```
-
-Result idea:
-
-```html
-<card-box id="intro" class="highlight">
-  <h2>Intro</h2>
-</card-box>
-```
-
-### Set explicit nesting level
-
-```html
-<h2 layout="3;card-box">Intro</h2>
-```
-
-- `3;...` forces level 3
-- `card-box` is the replacement element
-
-### Append to current section instead of creating a new one
-
-```html
-<h3 layout="+4;">Sub heading</h3>
-```
-
-### Skip section creation
-
-```html
-<h3 layout="-3;">Do not create a new section</h3>
-```
-
-## Section attributes
-
-Use `section-*` on source elements to configure the generated `<section>`.
-
-```html
-<h2 section-id="intro" section-class="hero" section-style="--cols: 6">
-  Intro
-</h2>
-```
-
-Result idea:
-
-```html
-<section id="intro" class="hero" style="--cols: 6">
-  <h2>Intro</h2>
-</section>
-```
-
-Shortcut via source classes:
-
-```html
-<h2 class="section-hero section-dark">Intro</h2>
-```
-
-Result idea:
-
-```html
-<section class="hero dark">
-  <h2>Intro</h2>
-</section>
-```
-
-## `hr` handling
-
-`<hr>` is ignored unless it has a `layout` attribute.
-
-```html
-<hr layout="grid-row">
-```
-
-## Skip layout replacement, keep section building only
-
-```html
-<tj-content-pane skip-layout>
-  ...
-</tj-content-pane>
-```
-
-## Event
+Use `applyLayout()` when the section tree already exists and only `layout` transforms should be applied:
 
 ```ts
-pane.addEventListener('afterArrange', (event) => {
-  console.log('tree built', event.detail.target);
-});
-```
-
-## Direct helper: `applyLayout()`
-
-```ts
-import { applyLayout } from '@trunkjs/content-pane';
-
 applyLayout(Array.from(container.children), { recursive: true });
 ```
 
-Use this when the section tree already exists and only `layout="..."` should be applied.
+Use `SubLayoutApplyMixin` for Lit components that re-slot or modify nested children.
 
-## Nested layout pattern: `SubLayoutApplyMixin`
+## Agent rules
 
-Use this for Lit elements that re-slot or re-tag their children.
-
-```ts
-import { LitElement, html } from 'lit';
-import { SubLayoutApplyMixin } from '@trunkjs/content-pane';
-
-class MyCard extends SubLayoutApplyMixin(LitElement) {
-  render() {
-    return html`
-      <slot name="header" data-query=":scope > h2"></slot>
-      <slot data-query=":scope > p" data-set-attribute-slot="body"></slot>
-    `;
-  }
-}
-```
-
-Useful slot attributes:
-- `data-query`
-- `data-set-attribute-*`
-- `name`
-
-## Agent hints
-
-- Prefer `<tj-content-pane>` for flat CMS / markdown HTML.
-- Prefer `layout="custom-tag#id.class[attr=value]"` instead of custom post-processing.
-- Use `skip-layout` if only section grouping is wanted.
-- Use `SubLayoutApplyMixin` for nested Lit-based layout components.
+1. **Prefer heading-attached layouts.** Let `h2`, `h3`, etc. define the normal page hierarchy.
+2. **Use `hr[layout]` for an extra wrapper between heading levels**, e.g. `i=2.5` between an H2 and its H3 children.
+3. **Specify `i` explicitly only when the desired layout hierarchy differs from the heading hierarchy.**
+4. Treat `i` as a tree coordinate: **smaller = outer, larger = deeper**.
+5. Avoid `i=1` unless a wrapper is intentionally meant to contain a large part of the page.
+6. Use `+i` to reuse an existing section at a level; use `-i` when the source element must not create its own section.

--- a/packages/content-pane/README.md
+++ b/packages/content-pane/README.md
@@ -1,49 +1,103 @@
 # TrunkJS Content-Pane
 
-Das `<tj-content-pane>` Element übernimmt zwei Aufgaben: 
+Das `<tj-content-pane>` Element übernimmt zwei Aufgaben:
 
-- Scritt 1: Es baut aus einer flachen HTML Struktur (H1-6, p, hr etc) eine Baumstruktur auf.
-- Scritt 2: Es ändert die tag-Names und Attribute der Elemente basierend auf den `layout` Attributen.
-
+1. Es baut aus einer flachen HTML-Struktur (`h1`–`h6`, `p`, `hr`, …) anhand des **Layout-Indexes `i`** eine verschachtelte Section-Struktur auf.
+2. Es transformiert die erzeugten Sections anhand ihrer `layout`-Attribute in die gewünschten Layout-Elemente.
 
 ## Schritt 1: Baumstruktur aufbauen
 
-Basierend auf dem `I`-Index baut die Komponente z.B. aus einer serverseitig
-generierten flachen HTML Struktur eine Baumstruktur auf
+### Der Layout-Index `i`
 
-| Element                | I-Index         |
-|------------------------|-----------------|
-| H1,H2                  | 2               |
-| H3                     | 3               |
-| H4                     | 4               |
-| H5                     | 5               |
-| H6                     | 6               |
-| hr mit layout-attribut | letzter I + 0.5 |
+`i` beschreibt die Schachteltiefe einer Section: **kleiner = weiter außen, größer = tiefer verschachtelt**.
 
-Dabei werden Element wie folgt verschachtelt:
+Standardmäßig wird `i` aus der Überschrift abgeleitet:
+
+| Element | `i` |
+| --- | ---: |
+| `h1`, `h2` | `2` |
+| `h3` | `3` |
+| `h4` | `4` |
+| `h5` | `5` |
+| `h6` | `6` |
+| `hr[layout]` ohne explizites `i` | letzter fester Index + `0.5` |
+
+`h1` wird absichtlich wie `h2` behandelt. Der normale Content-Baum beginnt damit bei `i = 2`.
+
+Ein Element mit größerem `i` wird unter dem vorherigen Element mit kleinerem `i` einsortiert. Ein neues Element auf derselben oder einer kleineren Ebene beendet die vorherige Verschachtelung entsprechend.
 
 ```text
-i1
-    i2
-       i2.5
-            i3
-            i3
-    i2
-        i3
-        i4
-        i3
+i=2
+  i=2.5
+    i=3
+    i=3
+  i=3
+i=2
 ```
+
+### Layouts bevorzugt an Überschriften setzen
+
+Layouts sollten standardmäßig direkt an die Überschrift gehängt werden, deren Section sie ersetzen sollen. Dadurch bleibt die semantische Überschriftenstruktur auch in der Layout-Struktur sichtbar.
+
+```html
+<h2 layout="page-section">Products</h2>
+<h3>Product A</h3>
+<h3>Product B</h3>
+```
+
+`page-section` liegt hier auf `i = 2`; die beiden `h3`-Sections auf `i = 3` werden darunter verschachtelt.
+
+### Zusätzliche Layout-Ebene mit `<hr>`
+
+Ein `<hr>` wird nur berücksichtigt, wenn es ein `layout`-Attribut besitzt. Ohne expliziten Index erhält es automatisch **den letzten festen Index + `0.5`**.
+
+Damit kann zwischen zwei Überschriftenebenen eine zusätzliche Layout-Ebene eingefügt werden:
+
+```html
+<h2>Products</h2>
+<hr layout="card-grid">
+<h3>Product A</h3>
+<h3>Product B</h3>
+```
+
+Ergibt konzeptionell:
+
+```text
+h2 section      i=2
+└─ card-grid    i=2.5
+   ├─ h3        i=3
+   └─ h3        i=3
+```
+
+`hr[layout]` ist daher die bevorzugte Syntax, wenn mehrere nachfolgende Elemente derselben tieferen Ebene gemeinsam in ein zusätzliches Layout gewrappt werden sollen.
+
+### Explizite Ebenen und Varianten
+
+Der optionale Präfix im `layout`-Attribut steuert Index und Verhalten:
+
+```html
+<h2 layout="3;card-box">...</h2>
+<h3 layout="+3;">...</h3>
+<h3 layout="-3;">...</h3>
+```
+
+- `i;layout` – neue Section auf dem expliziten Index `i` anlegen.
+- `+i;...` – das Element an die bereits vorhandene Section dieser Ebene anhängen, statt eine neue Section anzulegen.
+- `-i;...` – für dieses Element keine neue Section anlegen; es bleibt im aktuellen Container.
+- ohne explizites `i` – Ebene aus der Überschrift ableiten; bei `hr[layout]` den letzten festen Index + `0.5` verwenden.
+
+Ein Index wie `i = 1` kann für sehr äußere Wrapper, z. B. einen Seitenhintergrund, verwendet werden. Das sollte sparsam eingesetzt werden, da dadurch alle folgenden tieferen Ebenen in diesen Wrapper geraten.
 
 ### Übertragen von Attributen
 
-Attribute wie 'layout' und mit 'section-' geprefixte Attribute werden auf das `<section>` Element übertragen.
+Attribute wie `layout` und mit `section-` geprefixte Attribute werden auf das `<section>` Element übertragen.
 
 Beispiel:
 
 ```markdown
 ## Header 2
 {: layout="#id1.class1" section-class="abc"}
-````
+```
 
 Wird zu:
 
@@ -53,87 +107,64 @@ Wird zu:
 </section>
 ```
 
-***Achtung: In diesem Schritt werden die Tags noch nicht verändert!*** Dies erfolgt erst im Layout-Schritt.
+**Achtung:** In diesem Schritt werden die Tags noch nicht verändert. Dies erfolgt erst im Layout-Schritt.
 
-### Benutzerdefiniert I-Layer
+### Attribute für Section-Elemente setzen
 
-Über das `layout` Attribut kann ein benutzerdefinierter I-Layer definiert werden.
-
-Beispiel:
-
-```markdown
-## Header 2
-{: layout="3;"}
-```
-Dies würde das Element in den I-Layer 3 verschieben.
-
-### Attribute für section-Elemente setzen
-
-Über das `section-<attribut>` können Attribute für das generierte section-Element gesetzt werden:
+Über `section-<attribut>` können Attribute für das generierte Section-Element gesetzt werden:
 
 ```markdown
 ## Header 2
 {: section-id="meine-id" section-style="--cols: 6" section-class="highlight"}
 ```
 
-### Klassen-Shortcut für section-Elemente
+### Klassen-Shortcut für Section-Elemente
 
-Alle Klassen des Elements, die mit `section-` beginnen, werden auf das generierte section-Element übertragen.
+Alle Klassen des Elements, die mit `section-` beginnen, werden auf das generierte Section-Element übertragen.
 
+## Schritt 2: Apply Layouts
 
-
-### Das HR-Element
-
-Standardmäßig wird ein `<hr>` nicht behandelt, außer es hat ein layout-Attribut.
-
-Wenn kein dedizierter I-Layer angegeben ist, wird der I-Layer des vorherigen Elements + 0.5 verwendet.
-
-
-## Schritt 2: Apply-Layouts
-
-In diesem Schritt werden die layout-Attribute (ohne I-Layer) ausgewertet und die Elemente entsprechend umgewandelt.
+In diesem Schritt werden die `layout`-Attribute ohne Index-Präfix ausgewertet und die Section-Elemente entsprechend umgewandelt.
 
 Beispiel:
 
-````markdown
+```markdown
 ## Header 2
 {: layout="custom-element#id1.class1[slot=slotname]"}
-````
+```
 
-entpsricht:
+entspricht zunächst:
 
 ```html
 <section layout="custom-element#id1.class1[slot=slotname]">
     <h2>Header 2</h2>
 </section>
-``` 
-Wird zu: (*transformiert durch applyLayout()*)
+```
+
+und wird durch `applyLayout()` zu:
 
 ```html
 <custom-element class="class1" id="id1" slot="slotname">
-    <h2>Header 2</h2>   
+    <h2>Header 2</h2>
 </custom-element>
-``` 
+```
 
 ### Verschachtelte Layouts
 
-z.B. sollen Layout-Elemente die darunterliegenden Elemente verändern:
+Layout-Elemente können darunterliegende Elemente verändern, z. B. durch:
 
-- Automatisches zuweisen von `slot`-Attributen
-- Automatisches zuweisen von layout-Attributen
-
+- automatisches Zuweisen von `slot`-Attributen
+- automatisches Zuweisen von `layout`-Attributen
 
 #### Nutzung des `SubLayoutApplyMixin()`
 
-
-Das `SubLayoutApplyMixin()` kann genutzt werden, um verschachtelte Layouts zu realisieren.
-Es analysiert nach dem update() die slot-Elemente im Shadow-DOM. Selektiert werden Slot-elemente mit `data-query` Attribut.
+Das `SubLayoutApplyMixin()` kann genutzt werden, um verschachtelte Layouts zu realisieren. Es analysiert nach dem `update()` die Slot-Elemente im Shadow-DOM. Selektiert werden Slot-Elemente mit `data-query` Attribut.
 
 Beispiel:
 
 ```javascript
 class CustomElement extends SubLayoutApplyMixin(LitElement) {
-    ...
+    // ...
     render() {
         return html`
             <slot data-query=":scope > h2,h3,h4" name="header"></slot>
@@ -143,7 +174,6 @@ class CustomElement extends SubLayoutApplyMixin(LitElement) {
 }
 ```
 
-##### data-query
+##### `data-query`
 
-Data Query kann ein oder Mehrere durch `|` getrennte CSS-Selektoren enthalten. Das erste Element,
-das gefunden wird, wird verwendet.
+`data-query` kann einen oder mehrere durch `|` getrennte CSS-Selektoren enthalten. Das erste Element, das gefunden wird, wird verwendet.


### PR DESCRIPTION
## What changed

- explain the Content Pane layout index `i` as the nesting coordinate of the generated section tree
- document the default heading mapping (`h1`/`h2` = 2, `h3` = 3, etc.)
- clarify that `hr[layout]` without an explicit index uses the last fixed index + `0.5`
- recommend heading-attached layouts as the default so layout and semantic document structure stay aligned
- document `hr[layout]` as the preferred way to introduce an intermediate wrapper for following children
- clarify explicit `i`, `+i` append, and `-i` skip semantics
- add compact agent rules to `.ai-usage-info.md` for later reuse in skills

## Why

The existing documentation listed the individual syntax forms, but did not make the tree model behind `i` explicit. That makes it harder for both developers and agents to predict how layouts wrap subsequent content.

The updated docs center the mental model around `i` and show when to use heading layouts versus intermediate HR layouts.

## Validation

Documentation-only change. The documented behavior was checked against `SectionTreeBuilder.ts`, including H1→H2 index normalization, HR `+0.5` behavior, and the `new` / `append` / `skip` variants.