### PR TITLE
add router package

### DIFF
--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -1,0 +1,35 @@
+# TrunkJS Router
+
+Client-side routing for TrunkJS web components.
+
+```ts
+import { Router, route, setDefaultRouter, withRouter } from '@trunkjs/router';
+
+@route({ name: 'user', path: '/users/:id', meta: { title: 'User' } })
+class UserPage extends HTMLElement {}
+
+const router = new Router([UserPage]);
+setDefaultRouter(router);
+router.start();
+```
+
+Use `<router-content></router-content>` as the route outlet. Decorated components are rendered for matching routes.
+
+Components outside the outlet can subscribe through `withRouter`:
+
+```ts
+class Navigation extends withRouter(HTMLElement) {
+  override onRouteChange({ route }) {
+    console.log(route.params, route.meta);
+  }
+}
+```
+
+Generate and navigate by route name:
+
+```ts
+router.url({ name: 'user', params: { id: 42 } });
+router.navigate({ name: 'user', params: { id: 42 } });
+```
+
+Routes use SPA navigation by default. Set `navigation: 'reload'` on a route or pass it to `navigate`/`replace` for a full page navigation. Internal anchor clicks are intercepted when they match a route; use `data-router-ignore` to opt out or `data-router-reload` to force a reload.

--- a/packages/router/eslint.config.mjs
+++ b/packages/router/eslint.config.mjs
@@ -1,0 +1,12 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': ['error', { ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs}', '{projectRoot}/vite.config.{js,ts,mjs,mts}'] }],
+    },
+    languageOptions: { parser: await import('jsonc-eslint-parser') },
+  },
+];

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@trunkjs/router",
+  "version": "0.0.0",
+  "main": "./index.js",
+  "repository": {
+    "directory": "packages/router",
+    "type": "git",
+    "url": "https://github.com/trunkjs/trunkjs-monorepo"
+  },
+  "devDependencies": {
+    "@types/jsdom": "^21.1.7",
+    "jsdom": "^26.0.0",
+    "vitest": "^3.2.4"
+  },
+  "type": "module",
+  "types": "./index.d.ts"
+}

--- a/packages/router/project.json
+++ b/packages/router/project.json
@@ -1,0 +1,23 @@
+{
+  "name": "router",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "{projectRoot}/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/vite:build",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": { "outputPath": "dist/{projectRoot}" },
+      "configurations": {
+        "development": { "mode": "development" },
+        "production": { "mode": "production" }
+      }
+    },
+    "nx-release-publish": {
+      "executor": "@nx/js:release-publish",
+      "options": { "packageRoot": "dist/{projectRoot}" }
+    }
+  }
+}

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,0 +1,10 @@
+export * from './lib/router';
+export * from './lib/with-router';
+
+import { RouterContent } from './lib/with-router';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'router-content': RouterContent;
+  }
+}

--- a/packages/router/src/lib/router.spec.ts
+++ b/packages/router/src/lib/router.spec.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Router, route } from './router';
+import { setDefaultRouter, withRouter } from './with-router';
+
+describe('Router', () => {
+  beforeEach(() => history.replaceState({}, '', '/'));
+
+  it('matches decorated components and exposes params and metadata', () => {
+    @route({ name: 'user', path: '/users/:id', meta: { title: 'User' } })
+    class UserPage extends HTMLElement {}
+
+    const router = new Router([UserPage]);
+    const match = router.match('/users/42?tab=history');
+
+    expect(match?.name).toBe('user');
+    expect(match?.params.id).toBe('42');
+    expect(match?.query.get('tab')).toBe('history');
+    expect(match?.meta.title).toBe('User');
+  });
+
+  it('generates URLs from route names and parameters', () => {
+    @route({ name: 'user', path: '/users/:id' })
+    class UserPage extends HTMLElement {}
+
+    const router = new Router([UserPage]);
+    expect(router.url({ name: 'user', params: { id: 42 }, query: { tab: 'history' } })).toBe('/users/42?tab=history');
+  });
+
+  it('emits routechange for SPA navigation', () => {
+    @route({ name: 'user', path: '/users/:id' })
+    class UserPage extends HTMLElement {}
+
+    const router = new Router([UserPage]);
+    const listener = vi.fn();
+    router.addEventListener('routechange', listener);
+    router.navigate({ name: 'user', params: { id: 7 } });
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(router.current?.params.id).toBe('7');
+  });
+
+  it('withRouter calls onRouteChange and receives the current route on connect', () => {
+    @route({ name: 'home', path: '/' })
+    class HomePage extends HTMLElement {}
+
+    const router = new Router([HomePage]);
+    setDefaultRouter(router);
+    router.start();
+
+    class AwareElement extends withRouter(HTMLElement) {
+      calls = 0;
+      override onRouteChange() { this.calls += 1; }
+    }
+
+    const element = new AwareElement();
+    document.body.append(element);
+    expect(element.calls).toBe(1);
+    element.remove();
+    router.stop();
+  });
+});

--- a/packages/router/src/lib/router.ts
+++ b/packages/router/src/lib/router.ts
@@ -1,0 +1,229 @@
+export type NavigationMode = 'spa' | 'reload';
+
+export type RouteParams = Record<string, string | number>;
+export type RouteQuery = Record<string, string | number | boolean | undefined>;
+
+export interface RouteOptions {
+  name?: string;
+  path: string;
+  navigation?: NavigationMode;
+  meta?: Record<string, unknown>;
+}
+
+export interface RouteDefinition extends RouteOptions {
+  components: CustomElementConstructor[];
+}
+
+export type RouteTarget =
+  | string
+  | { name: string; params?: RouteParams; query?: RouteQuery; hash?: string }
+  | { path: string; query?: RouteQuery; hash?: string };
+
+export interface RouteContext {
+  readonly name?: string;
+  readonly path: string;
+  readonly url: URL;
+  readonly params: Readonly<Record<string, string>>;
+  readonly query: URLSearchParams;
+  readonly hash: string;
+  readonly meta: Readonly<Record<string, unknown>>;
+  readonly definition: RouteDefinition;
+  readonly router: Router;
+}
+
+export interface RouteChange {
+  readonly route: RouteContext;
+  readonly previousRoute: RouteContext | null;
+}
+
+export interface NavigationOptions {
+  navigation?: NavigationMode;
+}
+
+const ROUTES = Symbol('trunkjs.routes');
+
+type RoutableConstructor = CustomElementConstructor & {
+  [ROUTES]?: RouteOptions[];
+};
+
+export function route(path: string): <T extends CustomElementConstructor>(value: T) => T;
+export function route(options: RouteOptions): <T extends CustomElementConstructor>(value: T) => T;
+export function route(pathOrOptions: string | RouteOptions) {
+  const options: RouteOptions = typeof pathOrOptions === 'string' ? { path: pathOrOptions } : pathOrOptions;
+  return <T extends CustomElementConstructor>(value: T): T => {
+    const ctor = value as RoutableConstructor;
+    ctor[ROUTES] = [...(ctor[ROUTES] ?? []), options];
+    return value;
+  };
+}
+
+export function getRouteMetadata(component: CustomElementConstructor): readonly RouteOptions[] {
+  return (component as RoutableConstructor)[ROUTES] ?? [];
+}
+
+export class RouteChangeEvent extends CustomEvent<RouteChange> {
+  static readonly type = 'routechange';
+
+  constructor(change: RouteChange) {
+    super(RouteChangeEvent.type, { detail: change });
+  }
+}
+
+function compilePath(path: string) {
+  const names: string[] = [];
+  const escaped = path
+    .split('/')
+    .map((part) => {
+      if (part.startsWith(':')) {
+        names.push(part.slice(1));
+        return '([^/]+)';
+      }
+      return part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    })
+    .join('/');
+  return { names, regex: new RegExp(`^${escaped}/?$`) };
+}
+
+function queryString(query?: RouteQuery): string {
+  if (!query) return '';
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined) params.set(key, String(value));
+  }
+  const value = params.toString();
+  return value ? `?${value}` : '';
+}
+
+export class Router extends EventTarget {
+  readonly #routes: RouteDefinition[] = [];
+  #started = false;
+  current: RouteContext | null = null;
+
+  constructor(routes: Array<RouteDefinition | CustomElementConstructor> = []) {
+    super();
+    routes.forEach((entry) => {
+      if (typeof entry === 'function') this.register(entry);
+      else this.addRoute(entry);
+    });
+  }
+
+  addRoute(definition: RouteDefinition): this {
+    if (definition.name && this.#routes.some((route) => route.name === definition.name)) {
+      throw new Error(`Duplicate route name: ${definition.name}`);
+    }
+    this.#routes.push({ ...definition, navigation: definition.navigation ?? 'spa', meta: definition.meta ?? {} });
+    return this;
+  }
+
+  register(component: CustomElementConstructor): this {
+    for (const metadata of getRouteMetadata(component)) {
+      this.addRoute({ ...metadata, components: [component] });
+    }
+    return this;
+  }
+
+  start(): void {
+    if (this.#started) return;
+    this.#started = true;
+    window.addEventListener('popstate', this.#onPopState);
+    document.addEventListener('click', this.#onClick);
+    this.#commit(new URL(window.location.href));
+  }
+
+  stop(): void {
+    if (!this.#started) return;
+    this.#started = false;
+    window.removeEventListener('popstate', this.#onPopState);
+    document.removeEventListener('click', this.#onClick);
+  }
+
+  match(input: string | URL): RouteContext | null {
+    const url = input instanceof URL ? input : new URL(input, window.location.href);
+    for (const definition of this.#routes) {
+      const { names, regex } = compilePath(definition.path);
+      const match = regex.exec(url.pathname);
+      if (!match) continue;
+      const params = Object.fromEntries(names.map((name, index) => [name, decodeURIComponent(match[index + 1] ?? '')]));
+      return {
+        name: definition.name,
+        path: url.pathname,
+        url,
+        params,
+        query: url.searchParams,
+        hash: url.hash,
+        meta: definition.meta ?? {},
+        definition,
+        router: this,
+      };
+    }
+    return null;
+  }
+
+  url(target: RouteTarget): string {
+    if (typeof target === 'string') return target;
+    let path: string;
+    if ('name' in target) {
+      const definition = this.#routes.find((route) => route.name === target.name);
+      if (!definition) throw new Error(`Unknown route: ${target.name}`);
+      path = definition.path;
+      for (const [key, value] of Object.entries(target.params ?? {})) {
+        path = path.replace(`:${key}`, encodeURIComponent(String(value)));
+      }
+      if (/:[^/]+/.test(path)) throw new Error(`Missing route parameter for ${target.name}`);
+    } else {
+      path = target.path;
+    }
+    return `${path}${queryString(target.query)}${target.hash ? `#${target.hash.replace(/^#/, '')}` : ''}`;
+  }
+
+  navigate(target: RouteTarget, options: NavigationOptions = {}): RouteContext | null {
+    return this.#go(target, false, options);
+  }
+
+  replace(target: RouteTarget, options: NavigationOptions = {}): RouteContext | null {
+    return this.#go(target, true, options);
+  }
+
+  back(): void { history.back(); }
+  forward(): void { history.forward(); }
+
+  #go(target: RouteTarget, replace: boolean, options: NavigationOptions): RouteContext | null {
+    const href = this.url(target);
+    const nextUrl = new URL(href, window.location.href);
+    const matched = this.match(nextUrl);
+    const navigation = options.navigation ?? matched?.definition.navigation ?? 'spa';
+    if (navigation === 'reload') {
+      if (replace) window.location.replace(nextUrl.href);
+      else window.location.assign(nextUrl.href);
+      return matched;
+    }
+    if (replace) history.replaceState({}, '', nextUrl);
+    else history.pushState({}, '', nextUrl);
+    return this.#commit(nextUrl);
+  }
+
+  #commit(url: URL): RouteContext | null {
+    const next = this.match(url);
+    if (!next) return null;
+    const previousRoute = this.current;
+    this.current = next;
+    this.dispatchEvent(new RouteChangeEvent({ route: next, previousRoute }));
+    return next;
+  }
+
+  #onPopState = () => { this.#commit(new URL(window.location.href)); };
+
+  #onClick = (event: MouseEvent) => {
+    if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    const target = event.target instanceof Element ? event.target.closest('a[href]') : null;
+    if (!(target instanceof HTMLAnchorElement) || target.target || target.download || target.hasAttribute('data-router-ignore')) return;
+    const url = new URL(target.href, window.location.href);
+    if (url.origin !== window.location.origin) return;
+    const match = this.match(url);
+    if (!match) return;
+    event.preventDefault();
+    this.navigate(url.pathname + url.search + url.hash, {
+      navigation: target.hasAttribute('data-router-reload') ? 'reload' : undefined,
+    });
+  };
+}

--- a/packages/router/src/lib/with-router.ts
+++ b/packages/router/src/lib/with-router.ts
@@ -1,0 +1,61 @@
+type Constructor<T = object> = abstract new (...args: any[]) => T;
+
+export interface RouterAware {
+  readonly router: Router;
+  onRouteChange(change: RouteChange): void | Promise<void>;
+}
+
+let defaultRouter: Router | undefined;
+
+export function setDefaultRouter(router: Router): void {
+  defaultRouter = router;
+}
+
+export function getDefaultRouter(): Router {
+  if (!defaultRouter) throw new Error('No default router configured. Call setDefaultRouter(router) first.');
+  return defaultRouter;
+}
+
+export function withRouter<TBase extends Constructor<HTMLElement>>(Base: TBase) {
+  abstract class RouterAwareElement extends Base implements RouterAware {
+    #router?: Router;
+    #listener = (event: Event) => {
+      void this.onRouteChange((event as RouteChangeEvent).detail);
+    };
+
+    get router(): Router {
+      return this.#router ?? getDefaultRouter();
+    }
+
+    connectedCallback() {
+      // @ts-ignore mixins can extend HTMLElement subclasses with lifecycle methods
+      super.connectedCallback?.();
+      this.#router = getDefaultRouter();
+      this.#router.addEventListener(RouteChangeEvent.type, this.#listener);
+      if (this.#router.current) {
+        void this.onRouteChange({ route: this.#router.current, previousRoute: null });
+      }
+    }
+
+    disconnectedCallback() {
+      this.#router?.removeEventListener(RouteChangeEvent.type, this.#listener);
+      this.#router = undefined;
+      // @ts-ignore mixins can extend HTMLElement subclasses with lifecycle methods
+      super.disconnectedCallback?.();
+    }
+
+    onRouteChange(_change: RouteChange): void | Promise<void> {}
+  }
+
+  return RouterAwareElement;
+}
+
+export class RouterContent extends withRouter(HTMLElement) {
+  override onRouteChange({ route }: RouteChange): void {
+    this.replaceChildren(...route.definition.components.map((Component) => new Component()));
+  }
+}
+
+if (!customElements.get('router-content')) {
+  customElements.define('router-content', RouterContent);
+}

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2019",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "experimentalDecorators": false,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }, { "path": "./tsconfig.spec.json" }]
+}

--- a/packages/router/tsconfig.lib.json
+++ b/packages/router/tsconfig.lib.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "outDir": "../../dist/out-tsc", "types": ["node", "vite/client"] },
+  "include": ["src/**/*.ts"],
+  "exclude": ["vite.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/packages/router/tsconfig.spec.json
+++ b/packages/router/tsconfig.spec.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "outDir": "../../dist/out-tsc", "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"] },
+  "include": ["vite.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/packages/router/vite.config.ts
+++ b/packages/router/vite.config.ts
@@ -1,0 +1,32 @@
+/// <reference types='vitest' />
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import * as path from 'path';
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/router',
+  plugins: [
+    nxViteTsPaths(),
+    nxCopyAssetsPlugin(['*.md']),
+    dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'), aliasesExclude: [/@trunkjs\/.*/] }),
+  ],
+  build: {
+    outDir: '../../dist/packages/router',
+    emptyOutDir: true,
+    reportCompressedSize: true,
+    commonjsOptions: { transformMixedEsModules: true },
+    lib: { entry: 'src/index.ts', name: 'router', fileName: 'index', formats: ['es' as const] },
+    rollupOptions: { external: (id) => !id.startsWith('.') && !path.isAbsolute(id) },
+  },
+  test: {
+    watch: false,
+    globals: true,
+    environment: 'jsdom',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: { reportsDirectory: '../../coverage/packages/router', provider: 'v8' as const },
+  },
+}));

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,33 +1,34 @@
 {
-    "compileOnSave": false,
-    "compilerOptions": {
-        "rootDir": ".",
-        "sourceMap": true,
-        "declaration": false,
-        "moduleResolution": "node",
-        "emitDecoratorMetadata": false,
-        "experimentalDecorators": false,
-        "importHelpers": true,
-        "target": "es2022",
-        "module": "esnext",
-        "lib": ["es2020", "dom"],
-        "skipLibCheck": true,
-        "skipDefaultLibCheck": true,
-        "baseUrl": ".",
-        "paths": {
-            "@trunkjs/ast-markdown": ["packages/ast-markdown/src/index.ts"],
-            "@trunkjs/browser-utils": ["packages/browser-utils/src/index.ts"],
-            "@trunkjs/content-pane": ["packages/content-pane/src/index.ts"],
-            "@trunkjs/demo-viewer": ["packages/demo-viewer/src/index.ts"],
-            "@trunkjs/markdown-loader": ["packages/markdown-loader/src/index.ts"],
-            "@trunkjs/prolit": ["packages/prolit/src/index.ts"],
-            "@trunkjs/prolit-elements": ["packages/prolit-elements/src/index.ts"],
-            "@trunkjs/responsive": ["packages/responsive/src/index.ts"],
-            "@trunkjs/scrollspy": ["packages/scrollspy/src/index.ts"],
-            "@trunkjs/website-layout": ["demo/website-layout/src/index.ts"],
-            "@trunkjs/vite-demo-viewer": ["packages/vite-demo-viewer/src/index.ts"],
-            "@trunkjs/loader": ["./packages/loader/src/index.ts"]
-        }
-    },
-    "exclude": ["node_modules", "tmp"]
+  "compileOnSave": false,
+  "compilerOptions": {
+    "rootDir": ".",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": false,
+    "experimentalDecorators": false,
+    "importHelpers": true,
+    "target": "es2022",
+    "module": "esnext",
+    "lib": ["es2020", "dom"],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@trunkjs/ast-markdown": ["packages/ast-markdown/src/index.ts"],
+      "@trunkjs/browser-utils": ["packages/browser-utils/src/index.ts"],
+      "@trunkjs/content-pane": ["packages/content-pane/src/index.ts"],
+      "@trunkjs/demo-viewer": ["packages/demo-viewer/src/index.ts"],
+      "@trunkjs/markdown-loader": ["packages/markdown-loader/src/index.ts"],
+      "@trunkjs/prolit": ["packages/prolit/src/index.ts"],
+      "@trunkjs/prolit-elements": ["packages/prolit-elements/src/index.ts"],
+      "@trunkjs/responsive": ["packages/responsive/src/index.ts"],
+      "@trunkjs/router": ["packages/router/src/index.ts"],
+      "@trunkjs/scrollspy": ["packages/scrollspy/src/index.ts"],
+      "@trunkjs/website-layout": ["demo/website-layout/src/index.ts"],
+      "@trunkjs/vite-demo-viewer": ["packages/vite-demo-viewer/src/index.ts"],
+      "@trunkjs/loader": ["./packages/loader/src/index.ts"]
+    }
+  },
+  "exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
## What changed

Adds a new `@trunkjs/router` package under `packages/router` with:

- `Router` for route matching, SPA history navigation, full-page reload navigation, named-route URL generation, and internal link interception
- `@route(...)` standard decorator metadata on Web Component classes
- `RouteContext`, route parameters, query/hash and route metadata
- typed `routechange` events containing current and previous route state
- `withRouter` mixin that subscribes/unsubscribes with the component lifecycle and invokes `onRouteChange`
- initial route delivery to components that connect after routing has already started
- `<router-content>` Web Component that renders all components assigned to the active route
- tests covering decorated routes, matching, URL generation, events and the mixin lifecycle
- Nx/Vite/TypeScript package configuration and README documentation

## Why

This establishes a frontend routing primitive for TrunkJS Web Component applications while keeping responsibilities separated: the router owns matching/navigation, route decorators declare metadata, and the mixin bridges router events into component lifecycle hooks.

## Notes

SPA navigation is the default. Routes and individual navigation calls can opt into `reload`; anchors can use `data-router-ignore` or `data-router-reload`.

## Validation

The package follows the existing Nx/Vite package structure and includes Vitest/jsdom tests. The implementation was created through the GitHub connector, so the test suite has not been executed locally in this session.